### PR TITLE
Tavallisessa pelialkuasetelmassa Pa5 antoi virheen.

### DIFF
--- a/src/net/jokinagames/Koordinaatti.java
+++ b/src/net/jokinagames/Koordinaatti.java
@@ -139,9 +139,11 @@ public class Koordinaatti {
                         throw new PelkkaKohderuutuEiRiita("Siirto ei löytynyt, eikä lähtösaraketta tiedossa");
                     }
                 }
-            } else {
+            } else if(loydot.size()==1) {
                 // kätsy, oli vain se yksi siirto
                 a = loydot.get(0).annaLahtoruutu();
+            } else {
+                throw new KoordinaattiVirhe("Annettu siirto ei löytynyt");
             }
         }
 

--- a/src/net/jokinagames/Vari.java
+++ b/src/net/jokinagames/Vari.java
@@ -1,6 +1,6 @@
 package net.jokinagames;
 
-enum Vari {
+public enum Vari {
 	VALKOINEN,
 	MUSTA,
 	KATSOKIRJAIMESTA // käytetään FEN-parsinnassa

--- a/src/test/jokinagames/KoordinaattiTest.java
+++ b/src/test/jokinagames/KoordinaattiTest.java
@@ -1,6 +1,6 @@
 package test.jokinagames;
 
-import net.jokinagames.Koordinaatti;
+import net.jokinagames.*;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -30,5 +30,15 @@ public class KoordinaattiTest {
         Assert.assertThat(a1.annaSan(), is("a1"));
         Koordinaatti h1 = new Koordinaatti("h1");
         Assert.assertThat(h1.annaSan(), is("h1"));
+    }
+
+    @Test
+    public void yritaVirheellinenSiirto() {
+        Lauta l = PortableGameNotationReader.alustaTavallinenPeli();
+        try {
+            Koordinaatti.luoKoordinaatit("Pa5", Vari.VALKOINEN, l);
+        } catch (Exception e) {
+            Assert.assertTrue(e instanceof KoordinaattiVirhe);
+        }
     }
 }


### PR DESCRIPTION
luoKoordinaatit oli jonkin verran muutettu, muttei otettu
huomioon tilannetta, missä pitää eksplisiittisesti heittää
KoordinaattiVirheen kun ei löytynyt ollenkaan siirtoja.

Lisätty testi tätä tapausta varten.