### PR TITLE
Lisää siirtotestejä ja fiksejä.

### DIFF
--- a/src/net/jokinagames/Koordinaatti.java
+++ b/src/net/jokinagames/Koordinaatti.java
@@ -1,5 +1,6 @@
 package net.jokinagames;
 
+import javax.sound.sampled.Port;
 import java.util.List;
 
 /**
@@ -68,10 +69,12 @@ public class Koordinaatti {
 
         Nappula n;
 
+        String nappulat = l.annaSarakkeetMax()>=10 ? PortableGameNotationReader.nappulatSatu : PortableGameNotationReader.nappulat;
+
         String lahtoSarake = null;
-        if(san.length()>2 && PortableGameNotationReader.nappulat.indexOf(san.charAt(0))>-1) {
+        if(san.length()>2 && puhdistettuSan.matches("[a-zA-Z]{2}.*") && nappulat.indexOf(san.charAt(0))>-1) {
             // upseeri
-            char nappulaChar = san.charAt(0);
+            char nappulaChar = puhdistettuSan.charAt(0);
             n = Util.luoNappula(nappulaChar, vuoro, l.annaSarakkeetMax(), l.annaRivitMax());
             // nappulatyyppi handlattu, pidetään loput sanista
             puhdistettuSan = puhdistettuSan.substring(1);

--- a/src/net/jokinagames/PortableGameNotationReader.java
+++ b/src/net/jokinagames/PortableGameNotationReader.java
@@ -24,7 +24,8 @@ import java.util.stream.Collectors;
 public class PortableGameNotationReader {
     private final String gameFile;
     final private int firstPiece = (int)('\u2654');
-    static final public String nappulat = "KQACRBNPkqacrbnp";
+    static final public String nappulat = "KQRBNPkqrbnp";
+    static final public String nappulatSatu = "KQACRBNPkqacrbnp";
     static final public String sarakkeet = "abcdefghijklmnopqrstuvwxyz";
     static final public HashMap<Character, Character> nappulaMerkit = new HashMap<>();
     static private boolean nappulatAlustettu = false;
@@ -33,6 +34,7 @@ public class PortableGameNotationReader {
     static final public String capablancaUpseeriAsetelma = "RNABQKBCNR";
     static final public String perusFen = "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w - - 0 1";
     static final public String grandChessFen = "r8r/1nbqkcabn1/pppppppppp/10/10/10/10/PPPPPPPPPP/1NBQKCABN1/R8R w - - 0 1";
+    static final public String cpablancaFen = capablancaUpseeriAsetelma.toLowerCase()+"pppppppppp/10/10/10/10/PPPPPPPPPP/"+capablancaUpseeriAsetelma;
 
     /**
      * Konstruktori, joka ottaa polun PGN-tiedostoon.
@@ -513,6 +515,10 @@ public class PortableGameNotationReader {
      */
     public static Lauta alustaGrandChessPeli() {
         return parseFen(grandChessFen);
+    }
+
+    public static Lauta alustaCapablancaPeli() {
+        return parseFen(cpablancaFen);
     }
 
     /**

--- a/src/net/jokinagames/Sotilas.java
+++ b/src/net/jokinagames/Sotilas.java
@@ -61,7 +61,7 @@ public class Sotilas extends Nappula {
 			Siirto uS1 = new Siirto(A, uK);
 			siirrot.N.add(uS1);
 		} else if (lr==lahtorivimusta && this.annaVari() == Vari.MUSTA){
-			Koordinaatti uK = new Koordinaatti(koordinaatit.charAt(ls) + "" + (lr-3));
+			Koordinaatti uK = new Koordinaatti(koordinaatit.charAt(ls) + "" + (lr-1));
 			Siirto uS1 = new Siirto(A, uK);
 			siirrot.S.add(uS1);
 		}

--- a/src/test/jokinagames/LautaTest.java
+++ b/src/test/jokinagames/LautaTest.java
@@ -15,7 +15,7 @@ public class LautaTest {
     public void annaNappulatJoillaSiirtoMahdollinen() {
         Lauta l = PortableGameNotationReader.parseFen("8/8/8/2pppp2/2PPPP2/8/8/8");
         try {
-            Siirto s = Koordinaatti.luoKoordinaatit("xde4", Vari.MUSTA, l);
+            Siirto s = Koordinaatti.luoKoordinaatit("dxe4", Vari.MUSTA, l);
             List<Siirto> siirrot = l.annaNappulatJoillaSiirtoMahdollinen(s.annaKohderuutu(), new Sotilas(Vari.MUSTA, 8, 8));
             Assert.assertThat("kaksi voi syödä", siirrot.size(), is(2));
             Nappula n = l.annaNappula(s.annaLahtoruutu());
@@ -24,6 +24,36 @@ public class LautaTest {
             Assert.assertThat("Musta sotilas voisi teoriassa kolmeen suuntaan mennä", mahdolliset.siirrotYhteensa(), is(3));
             Siirrot sallitut = l.sallitutSiirrot(mahdolliset);
             Assert.assertThat("Asetelmassa musta voi siirtyä vain kahteen suuntaan - syödä valkoiset", sallitut.siirrotYhteensa(), is(2));
+        } catch (Exception e) {
+            e.printStackTrace();
+            Assert.assertThat("Odottamaton virhe", false, is(true));
+        }
+    }
+
+    @Test
+    public void varmistaSotilaanAloitussiirrot()
+    {
+        Lauta l = PortableGameNotationReader.alustaTavallinenPeli();
+        try {
+            Siirto s = Koordinaatti.luoKoordinaatit("e4", Vari.VALKOINEN, l);
+            Assert.assertThat("Aloitusruutu on e2", s.annaLahtoruutu(), is(new Koordinaatti("e2")));
+            Assert.assertThat("Kohderuutu on e4", s.annaKohderuutu(), is(new Koordinaatti("e4")));
+            s = Koordinaatti.luoKoordinaatit("a5", Vari.MUSTA, l);
+            Assert.assertThat("Aloitusruutu on a7", s.annaLahtoruutu(), is(new Koordinaatti("a7")));
+            Assert.assertThat("Kohderuutu on a5", s.annaKohderuutu(), is(new Koordinaatti("a5")));
+        } catch (Exception e) {
+            e.printStackTrace();
+            Assert.assertThat("Odottamaton virhe", false, is(true));
+        }
+
+        l = PortableGameNotationReader.alustaGrandChessPeli();
+        try {
+            Siirto s = Koordinaatti.luoKoordinaatit("i5", Vari.VALKOINEN, l);
+            Assert.assertThat("Aloitusruutu on i3", s.annaLahtoruutu(), is(new Koordinaatti("i3")));
+            Assert.assertThat("Kohderuutu on i5", s.annaKohderuutu(), is(new Koordinaatti("i5")));
+            s = Koordinaatti.luoKoordinaatit("j6", Vari.MUSTA, l);
+            Assert.assertThat("Aloitusruutu on j8", s.annaLahtoruutu(), is(new Koordinaatti("j8")));
+            Assert.assertThat("Kohderuutu on j6", s.annaKohderuutu(), is(new Koordinaatti("j6")));
         } catch (Exception e) {
             e.printStackTrace();
             Assert.assertThat("Odottamaton virhe", false, is(true));
@@ -51,19 +81,6 @@ public class LautaTest {
             e.printStackTrace();
             Assert.assertThat("Odottamaton virhe", false, is(true));
         }
-
-    }
-
-    @Test
-    public void annaKaikkiKoordinaatit() {
-    }
-
-    @Test
-    public void etsiKuningas() {
-    }
-
-    @Test
-    public void annaNappula() {
     }
 
     @Test


### PR DESCRIPTION
* Sotilas mustan aloitusriviltä ei pystynyt hyppäämään
  kahta eteenpäin.
* Peruslaudalla 8x8 voi syöttää sotilassiirrot ilman sotilaan
  merkintää
* Muilla laudoilla (eli satunappulat käytössä) on pakko
  myös kertoa sotilaan kirjain: "pa6" grand chessisä.